### PR TITLE
tests: fix harmless whitespace changes in expected strings

### DIFF
--- a/tests/interpolation.rs
+++ b/tests/interpolation.rs
@@ -36,7 +36,7 @@ fn test_substitution() {
     let x = X;
     let tokens = quote!(#x <#x> (#x) [#x] {#x});
 
-    let expected = "X < X > ( X ) [ X ] { X }";
+    let expected = "X < X > (X) [X] { X }";
 
     assert_eq!(expected, tokens.to_string());
 }
@@ -81,10 +81,10 @@ fn test_advanced() {
         "phantom : :: std :: marker :: PhantomData <Cow < 'a , str > >, ",
         "} ",
         "impl < 'a , T > :: serde :: Serialize for SerializeWith < 'a , T > where T : Serialize { ",
-        "fn serialize < S > ( & self , s : & mut S ) -> Result < ( ) , S :: Error > ",
+        "fn serialize < S > (& self , s : & mut S) -> Result < () , S :: Error > ",
         "where S : :: serde :: Serializer ",
         "{ ",
-        "SomeTrait :: serialize_with ( self . value , s ) ",
+        "SomeTrait :: serialize_with (self . value , s) ",
         "} ",
         "} ",
         "SerializeWith { ",

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -16,8 +16,8 @@ fn test_quote_impl() {
 
     let expected = concat!(
         "impl < 'a , T : ToTokens > ToTokens for & 'a T { ",
-        "fn to_tokens ( & self , tokens : & mut TokenStream ) { ",
-        "( ** self ) . to_tokens ( tokens ) ",
+        "fn to_tokens (& self , tokens : & mut TokenStream) { ",
+        "(** self) . to_tokens (tokens) ",
         "} ",
         "}"
     );

--- a/tests/types.rs
+++ b/tests/types.rs
@@ -23,7 +23,7 @@ fn test_integer() {
         #ii8 #ii16 #ii32 #ii64 #iisize
         #uu8 #uu16 #uu32 #uu64 #uusize
     };
-    let expected = "-1i8 -1i16 -1i32 -1i64 -1isize 1u8 1u16 1u32 1u64 1usize";
+    let expected = "- 1i8 - 1i16 - 1i32 - 1i64 - 1isize 1u8 1u16 1u32 1u64 1usize";
     assert_eq!(expected, tokens.to_string());
 }
 


### PR DESCRIPTION
Looks like some change (either in recent Rust or in a recent dependency update) caused cosmetic whitespace changes and makes some tests fail. This PR adapts the expected strings.

As far as I can tell, all whitespace changes are harmless:

- removed spaces within () parentheses and [] brackets
- added space between unary minus operator and number for negative numbers

The second one looks weird, but I suppose the syntax is still correct.

This makes all tests pass with updated dependencies on both current stable Rust 1.50.0 and nightly rust (1.52.0).